### PR TITLE
Pass cargolock/cargotoml via file instead of via env var

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -122,7 +122,7 @@ with rec
               then
                 echo "WARNING: replacing existing Cargo.lock"
               fi
-              echo "$cargolock" > Cargo.lock
+              install -m 644 "$cargolock" Cargo.lock
             fi
 
             if [ -n "$cargotoml" ]
@@ -132,7 +132,7 @@ with rec
               then
                 echo "WARNING: replacing existing Cargo.toml"
               fi
-              echo "$cargotoml" > Cargo.toml
+              install -m 644 "$cargotoml" Cargo.toml
             fi
 
             mkdir -p target
@@ -245,9 +245,9 @@ with rec
           '';
       } //
       lib.optionalAttrs (! isNull cargolock )
-        { cargolock = builtinz.toTOML cargolock; } //
+        { cargolock = builtinz.writeTOML "Cargo.lock" cargolock; } //
       lib.optionalAttrs (! isNull cargotoml )
-        { cargotoml = builtinz.toTOML cargotoml; }
+        { cargotoml = builtinz.writeTOML "Cargo.toml" cargotoml; }
       )
       ;
 

--- a/builtins/default.nix
+++ b/builtins/default.nix
@@ -8,7 +8,7 @@
 rec
 {
     toTOML = import ./to-toml.nix { inherit lib; };
-    writeTOML = attrs: writeText "write-toml" (toTOML attrs);
+    writeTOML = name: attrs: writeText name (toTOML attrs);
 
     readTOML = usePure: f:
       if usePure then


### PR DESCRIPTION
Apparently the `cargolock` env var can become too big so we replace it with a file. This fixes the following error:

```
building 
'/nix/store/s8bv90acizsyvh1s9gk7yvpiyw2gcpnx-dfinity-application-and-others-deps.drv'... 
while setting up the build environment: executing 
'/nix/store/cinw572b38aln37glr0zb8lxwrgaffl4-bash-4.4-p23/bin/bash': 
Argument list too long
```

See the following on the background of why env vars can become too big:
https://stackoverflow.com/questions/28865473/setting-environment-variable-to-a-large-value-argument-list-too-long