### PR TITLE
cargo build/test with --frozen to ensure Cargo.lock is up to date

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -96,10 +96,14 @@ with rec
             find . -type f -name '*.rs' -exec touch {} +
           '';
           cargoBuild = attrs.cargoBuild or ''
-            cargo build "''${cargo_release}" -j $NIX_BUILD_CORES -Z unstable-options --out-dir out
+            cargo build "''${cargo_release}" \
+              --frozen \
+              -j $NIX_BUILD_CORES \
+              -Z unstable-options \
+              --out-dir out
           '';
           cargoTestCommands = attrs.cargoTestCommands or [
-            ''cargo test "''${cargo_release}" -j $NIX_BUILD_CORES''
+            ''cargo test "''${cargo_release}" --frozen -j $NIX_BUILD_CORES''
           ];
         };
       buildPackageSingleStep = src: attrs:


### PR DESCRIPTION
For example if I change the name `simple-dep` to `simple_dep` in
`test/simple-dep/Cargo.toml` and build without this commit I don't get
any errors. If I run with this commit I get:

```
cargo build --release --frozen -j 6 -Z unstable-options --out-dir out
error: the lock file /private/var/folders/5h/b11m6fxj2tqgbxwz5bgjy42c0000gn/T/nix-build-some-name.drv-0/dummy-src/Cargo.lock needs to be updated but --frozen was passed to prevent this
```