### PR TITLE
Clean up, take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Naersk
 
+[![CircleCI](https://circleci.com/gh/nmattia/naersk.svg?style=svg)](https://circleci.com/gh/nmattia/naersk)
+
 Nix support for building [cargo] crates.
 
 ## Install

--- a/build.nix
+++ b/build.nix
@@ -29,19 +29,17 @@ src:
   #  Which drops the run-time dependency on the crates-io source thereby
   #  significantly reducing the Nix closure size.
 , removeReferencesToSrcFromDocs ? true
+, cratePaths
 , name
 , version
 , rustc
 , cargo
 , override ? null
 , buildInputs ? []
-, nativeBuildInputs ? []
 , builtDependencies ? []
-, replaceToml ? true
 , release ? true
 , stdenv
 , lib
-, llvmPackages
 , rsync
 , jq
 , darwin
@@ -50,8 +48,6 @@ src:
 , runCommand
 , remarshal
 , crateDependencies
-# TODO: rename to "members"
-, cratePaths
 }:
 
 with

--- a/build.nix
+++ b/build.nix
@@ -30,8 +30,9 @@ src:
   #  significantly reducing the Nix closure size.
 , removeReferencesToSrcFromDocs ? true
 , cratePaths
-, name
+, pname
 , version
+, name ? "${pname}-${version}"
 , rustc
 , cargo
 , override ? null
@@ -101,6 +102,9 @@ with rec
           darwin.cf-private
           ] ++ buildInputs;
 
+        # iff not in a shell
+        inherit builtDependencies;
+
         RUSTC="${rustc}/bin/rustc";
 
         configurePhase =
@@ -116,10 +120,7 @@ with rec
 
             mkdir -p target
 
-            cat ${builtinz.writeJSON "dependencies-json" builtDependencies} |\
-              jq -r '.[]' |\
-              while IFS= read -r dep
-              do
+            for dep in $builtDependencies; do
                 echo pre-installing dep $dep
                 rsync -rl \
                   --no-perms \

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,6 @@
 , symlinkJoin
 , stdenv
 , writeText
-, llvmPackages
 , jq
 , rsync
 , darwin
@@ -18,7 +17,6 @@ with
 let
   defaultBuildAttrs =
       { inherit
-          llvmPackages
           jq
           runCommand
           lib

--- a/default.nix
+++ b/default.nix
@@ -105,6 +105,11 @@ with rec
           # are the members. Otherwise, there is a single path, ".".
           cratePaths = lib.concatStringsSep "\n" wantedMembers;
 
+          packageName = attrs.name or toplevelCargotoml.package.name or
+            (if isWorkspace then "rust-workspace" else "rust-package");
+
+          packageVersion = attrs.version or toplevelCargotoml.package.version or
+            "unknown";
 
           # The list of _all_ crates (incl. transitive dependencies) with name,
           # version and sha256 of the crate
@@ -131,8 +136,8 @@ with rec
         with (commonAttrs src attrs);
         import ./build.nix src
           (defaultBuildAttrs //
-            { name = "${attrs.name or "unnamed"}-built";
-              version = "unknown";
+            { pname = packageName;
+              version = packageVersion;
               inherit cratePaths crateDependencies preBuild cargoBuild cargoTestCommands;
             } //
             (removeAttrs attrs [ "targets" "usePureFromTOML" "cargotomls" "singleStep" ]) //
@@ -150,8 +155,8 @@ with rec
                     }
                   )
                   (defaultBuildAttrs //
-                    { name = "${attrs.name or "unnamed"}-deps-built";
-                      version = "unknown";
+                    { pname = "${packageName}-deps";
+                      version = packageVersion;
                       inherit cratePaths crateDependencies cargoBuild;
                     } //
                   (removeAttrs attrs [ "targets" "usePureFromTOML" "cargotomls"  "singleStep"]) //

--- a/default.nix
+++ b/default.nix
@@ -49,10 +49,12 @@ with rec
           isSingleStep = attrs.singleStep or false;
 
           # The members we want to build
+          # (list of directory names)
           wantedMembers =
             lib.mapAttrsToList (member: _cargotoml: member) wantedMemberCargotomls;
 
           # Member path to cargotoml
+          # (attrset from directory name to Nix object)
           wantedMemberCargotomls =
             let pred =
               if ! isWorkspace
@@ -63,7 +65,8 @@ with rec
                 else (member: _cargotoml: member != "."); in
             lib.filterAttrs pred cargotomls;
 
-          # All cargotoml, from path to nix object
+          # All cargotomls, from path to nix object
+          # (attrset from directory name to Nix object)
           cargotomls =
             let readTOML = builtinz.readTOML usePureFromTOML; in
 
@@ -103,12 +106,21 @@ with rec
           # The list of paths to Cargo.tomls. If this is a workspace, the paths
           # are the members. Otherwise, there is a single path, ".".
           cratePaths = lib.concatStringsSep "\n" wantedMembers;
+
+
+          # The list of _all_ crates (incl. transitive dependencies) with name,
+          # version and sha256 of the crate
+          # Example:
+          #   [ { name = "wabt", version = "2.0.6", sha256 = "..." } ]
           crateDependencies = libb.mkVersions cargolock;
+
           preBuild = ''
-            # Cargo uses mtime, and we write `src/main.rs` in the dep build
-            # step, so make sure cargo rebuilds stuff
-            find . -type f -name '*.rs' -exec touch {} +
+            # Cargo uses mtime, and we write `src/lib.rs` and `src/main.rs`in
+            # the dep build step, so make sure cargo rebuilds stuff
+            if [ -f src/lib.rs ] ; then touch src/lib.rs; fi
+            if [ -f src/main.rs ] ; then touch src/main.rs; fi
           '';
+
           cargoBuild = attrs.cargoBuild or ''
             cargo build "''${cargo_release}" -j $NIX_BUILD_CORES -Z unstable-options --out-dir out
           '';

--- a/lib.nix
+++ b/lib.nix
@@ -7,8 +7,10 @@ with
   };
 rec
 {
-    # creates an attrset from package name to package version + sha256
-    # (note: this includes the package's dependencies)
+    # The list of _all_ crates (incl. transitive dependencies) with name,
+    # version and sha256 of the crate
+    # Example:
+    #   [ { name = "wabt", version = "2.0.6", sha256 = "..." } ]
     mkVersions = cargolock:
       if builtins.hasAttr "metadata" cargolock then
 
@@ -90,7 +92,7 @@ rec
       }:
       let
         config = writeText "config" cargoconfig;
-        cargolock' = builtinz.writeTOML "Cargo.toml" cargolock;
+        cargolock' = builtinz.writeTOML "Cargo.lock" cargolock;
         fixupCargoToml = cargotoml:
           let attrs =
                 # Since we pretend everything is a lib, we remove any mentions
@@ -101,7 +103,7 @@ rec
                       };
         cargotomlss = writeText "foo"
           (lib.concatStrings (lib.mapAttrsToList
-            (k: v: "${k}\n${builtinz.writeTOML "Cargo.toml-ds-aa" (fixupCargoToml v)}\n")
+            (k: v: "${k}\n${builtinz.writeTOML "Cargo.toml" (fixupCargoToml v)}\n")
             cargotomls
           ));
 

--- a/lib.nix
+++ b/lib.nix
@@ -101,14 +101,16 @@ rec
           in attrs // lib.optionalAttrs (lib.hasAttr "package" attrs) {
                         package = removeAttrs attrs.package [ "build" ];
                       };
-        cargotomlss = writeText "foo"
-          (lib.concatStrings (lib.mapAttrsToList
-            (k: v: "${k}\n${builtinz.writeTOML "Cargo.toml" (fixupCargoToml v)}\n")
-            cargotomls
-          ));
+
+        # a list of tuples from member to cargo toml:
+        #   "foo-member:/path/to/toml bar:/path/to/other-toml"
+        cargotomlss = lib.mapAttrsToList
+            (k: v: "${k}:${builtinz.writeTOML "Cargo.toml" (fixupCargoToml v)}")
+            cargotomls;
 
       in
-      runCommand "dummy-src" { inherit patchedSources; }
+      runCommand "dummy-src"
+        { inherit patchedSources cargotomlss; }
       ''
         mkdir -p $out/.cargo
         ${lib.optionalString (! isNull cargoconfig) "cp ${config} $out/.cargo/config"}
@@ -119,9 +121,10 @@ rec
           cp -R "$p" "$out/"
         done
 
-        cat ${cargotomlss} | \
-          while IFS= read -r member; do
-            read -r cargotoml
+        for tuple in $cargotomlss; do
+            member="''${tuple%%:*}"
+            cargotoml="''${tuple##*:}"
+
             final_dir="$out/$member"
             mkdir -p "$final_dir"
             final_path="$final_dir/Cargo.toml"
@@ -132,7 +135,7 @@ rec
             mkdir -p src
             touch src/lib.rs
             popd > /dev/null
-          done
+        done
       '';
 
     mkPackages = cargolock:


### PR DESCRIPTION
* general build code cleanup
* reduce number of derivations built
* remove occurrences of `foo`, `bar` and other silly names
* set name and version based on package metadata