### PR TITLE
Remove `name` from `attrs` for the deps build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -159,7 +159,7 @@ with rec
                       version = packageVersion;
                       inherit cratePaths crateDependencies cargoBuild;
                     } //
-                  (removeAttrs attrs [ "targets" "usePureFromTOML" "cargotomls"  "singleStep"]) //
+                  (removeAttrs attrs [ "targets" "usePureFromTOML" "cargotomls" "singleStep" "name" ]) //
                   { preBuild = "";
                     cargoTestCommands = map (cmd: "${cmd} || true") cargoTestCommands;
                     copyTarget = true;


### PR DESCRIPTION
Otherwise the nicely generated:

`pname = "${packageName}-deps"`

gets overridden by `name` if the user specifies a name.