### PR TITLE
Refactor configuration

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -29,7 +29,6 @@ src:
   #  Which drops the run-time dependency on the crates-io source thereby
   #  significantly reducing the Nix closure size.
 , removeReferencesToSrcFromDocs
-, cratePaths
 , pname
 , version
 , rustc
@@ -64,7 +63,6 @@ let
       inherit
         src
         doCheck
-        cratePaths
         version
         preBuild;
 

--- a/build.nix
+++ b/build.nix
@@ -4,17 +4,15 @@ src:
 , cargoBuild
 , #| What command to run during the test phase
   cargoTestCommands
-  #| Whether or not to forward intermediate build artifacts to $out
-, copyTarget ? false
+, copyTarget
   #| Whether or not to compress the target when copying it
 , compressTarget
   #| Whether or not to copy binaries to $out/bin
-, copyBins ? true
-, doCheck ? true
-, doDoc ? true
-  #| Whether or not the rustdoc can fail the build
-, doDocFail ? false
-, copyDocsToSeparateOutput ? true
+, copyBins
+, doCheck
+, doDoc
+, doDocFail
+, copyDocsToSeparateOutput
   #| Whether to remove references to source code from the generated cargo docs
   #  to reduce Nix closure size. By default cargo doc includes snippets like the
   #  following in the generated highlighted source code in files like: src/rand/lib.rs.html:
@@ -30,17 +28,16 @@ src:
   #
   #  Which drops the run-time dependency on the crates-io source thereby
   #  significantly reducing the Nix closure size.
-, removeReferencesToSrcFromDocs ? true
+, removeReferencesToSrcFromDocs
 , cratePaths
 , pname
 , version
-, name ? "${pname}-${version}"
 , rustc
 , cargo
-, override ? null
-, buildInputs ? []
-, builtDependencies ? []
-, release ? true
+, override
+, buildInputs
+, builtDependencies
+, release
 , stdenv
 , lib
 , rsync
@@ -61,183 +58,182 @@ with
         { inherit lib writeText remarshal runCommand ; };
   };
 
-with rec
-  {
-    drv = stdenv.mkDerivation (
-      { inherit
-          src
-          doCheck
-          cratePaths
-          name
-          version
-          preBuild;
+let
+  drv = stdenv.mkDerivation (
+    { name = "${pname}-${version}";
+      inherit
+        src
+        doCheck
+        cratePaths
+        version
+        preBuild;
 
-        cargoconfig = builtinz.toTOML
-          { source =
-              { crates-io = { replace-with = "nix-sources"; } ;
-                nix-sources =
-                  { directory = symlinkJoin
-                      { name = "crates-io";
-                        paths = map (v: unpackCrate v.name v.version v.sha256)
-                          crateDependencies;
-                      };
-                  };
-              };
-          };
+      cargoconfig = builtinz.toTOML
+        { source =
+            { crates-io = { replace-with = "nix-sources"; } ;
+              nix-sources =
+                { directory = symlinkJoin
+                    { name = "crates-io";
+                      paths = map (v: unpackCrate v.name v.version v.sha256)
+                        crateDependencies;
+                    };
+                };
+            };
+        };
 
-        outputs = [ "out" ] ++ lib.optional (doDoc && copyDocsToSeparateOutput) "doc";
-        preInstallPhases = lib.optional doDoc [ "docPhase" ];
+      outputs = [ "out" ] ++ lib.optional (doDoc && copyDocsToSeparateOutput) "doc";
+      preInstallPhases = lib.optional doDoc [ "docPhase" ];
 
-        # Otherwise specifying CMake as a dep breaks the build
-        dontUseCmakeConfigure = true;
+      # Otherwise specifying CMake as a dep breaks the build
+      dontUseCmakeConfigure = true;
 
-        nativeBuildInputs =
-          [ cargo
-            # needed at various steps in the build
-            jq
-            rsync
-          ] ;
+      nativeBuildInputs =
+        [ cargo
+          # needed at various steps in the build
+          jq
+          rsync
+        ] ;
 
-        buildInputs =
-          stdenv.lib.optionals stdenv.isDarwin
-          [ darwin.Security
-          darwin.apple_sdk.frameworks.CoreServices
-          darwin.cf-private
-          ] ++ buildInputs;
+      buildInputs =
+        stdenv.lib.optionals stdenv.isDarwin
+        [ darwin.Security
+        darwin.apple_sdk.frameworks.CoreServices
+        darwin.cf-private
+        ] ++ buildInputs;
 
-        # iff not in a shell
-        inherit builtDependencies;
+      # iff not in a shell
+      inherit builtDependencies;
 
-        RUSTC="${rustc}/bin/rustc";
+      RUSTC="${rustc}/bin/rustc";
 
-        configurePhase =
-          ''
-            cargo_release=( ${lib.optionalString release "--release" } )
+      configurePhase =
+        ''
+          cargo_release=( ${lib.optionalString release "--release" } )
 
-            runHook preConfigure
+          runHook preConfigure
 
-            logRun() {
-              echo "$@"
-              eval "$@"
-            }
+          logRun() {
+            echo "$@"
+            eval "$@"
+          }
 
-            mkdir -p target
+          mkdir -p target
 
-            for dep in $builtDependencies; do
-                echo pre-installing dep $dep
-                if [ -d "$dep/target" ]; then
-                  rsync -rl \
-                    --no-perms \
-                    --no-owner \
-                    --no-group \
-                    --chmod=+w \
-                    --executability $dep/target/ target
-                fi
-                if [ -f "$dep/target.tar.zst" ]; then
-                  ${zstd}/bin/zstd -d "$dep/target.tar.zst" --stdout | tar -x
-                fi
+          for dep in $builtDependencies; do
+              echo pre-installing dep $dep
+              if [ -d "$dep/target" ]; then
+                rsync -rl \
+                  --no-perms \
+                  --no-owner \
+                  --no-group \
+                  --chmod=+w \
+                  --executability $dep/target/ target
+              fi
+              if [ -f "$dep/target.tar.zst" ]; then
+                ${zstd}/bin/zstd -d "$dep/target.tar.zst" --stdout | tar -x
+              fi
 
-                if [ -d "$dep/target" ]; then
-                  chmod +w -R target
-                fi
-              done
+              if [ -d "$dep/target" ]; then
+                chmod +w -R target
+              fi
+            done
 
-            export CARGO_HOME=''${CARGO_HOME:-$PWD/.cargo-home}
-            mkdir -p $CARGO_HOME
+          export CARGO_HOME=''${CARGO_HOME:-$PWD/.cargo-home}
+          mkdir -p $CARGO_HOME
 
-            echo "$cargoconfig" > $CARGO_HOME/config
+          echo "$cargoconfig" > $CARGO_HOME/config
 
-            # TODO: figure out why "1" works whereas "0" doesn't
-            find . -type f -exec touch --date=@1 {} +
+          # TODO: figure out why "1" works whereas "0" doesn't
+          find . -type f -exec touch --date=@1 {} +
 
-            runHook postConfigure
-          '';
-
-        buildPhase =
-          ''
-            runHook preBuild
-
-            logRun ${cargoBuild}
-
-            runHook postBuild
-          '';
-
-        checkPhase =
-          ''
-            runHook preCheck
-
-            ${lib.concatMapStringsSep "\n" (cmd: "logRun ${cmd}") cargoTestCommands}
-
-            runHook postCheck
-          '';
-
-
-        docPhase = lib.optionalString doDoc ''
-          runHook preDoc
-
-          logRun cargo doc --offline "''${cargo_release[*]}" || ${if doDocFail then "false" else "true" }
-
-          ${lib.optionalString removeReferencesToSrcFromDocs ''
-          # Remove references to the source derivation to reduce closure size
-                match='<meta name="description" content="Source to the Rust file `${builtins.storeDir}[^`]*`.">'
-          replacement='<meta name="description" content="Source to the Rust file removed to reduce Nix closure size.">'
-          find target/doc -name "*\.rs\.html" -exec sed -i "s|$match|$replacement|" {} +
-          ''}
-
-          runHook postDoc
+          runHook postConfigure
         '';
 
-        installPhase =
-          ''
-            runHook preInstall
+      buildPhase =
+        ''
+          runHook preBuild
 
-            ${lib.optionalString copyBins ''
-            if [ -d out ]; then
-              mkdir -p $out/bin
-              find out -type f -executable -exec cp {} $out/bin \;
-            fi
-            ''}
+          logRun ${cargoBuild}
 
-            ${lib.optionalString copyTarget ''
-            mkdir -p $out
-            ${if compressTarget then
-            ''
-            tar -c target | ${zstd}/bin/zstd -o $out/target.tar.zst
-            '' else
-            ''
-            cp -r target $out
-            ''}
-            ''}
+          runHook postBuild
+        '';
 
-            ${lib.optionalString (doDoc && copyDocsToSeparateOutput) ''
-            cp -r target/doc $doc
-            ''}
+      checkPhase =
+        ''
+          runHook preCheck
 
-            runHook postInstall
-          '';
-        passthru = {
-          # Handy for debugging
-          inherit builtDependencies;
-        };
-      }
-      )
-      ;
+          ${lib.concatMapStringsSep "\n" (cmd: "logRun ${cmd}") cargoTestCommands}
 
-    # XXX: the actual crate format is not documented but in practice is a
-    # gzipped tar; we simply unpack it and introduce a ".cargo-checksum.json"
-    # file that cargo itself uses to double check the sha256
-    unpackCrate = name: version: sha256:
-      with
-      { crate = builtins.fetchurl
-          { url = "https://crates.io/api/v1/crates/${name}/${version}/download";
-            inherit sha256;
-          };
-      };
-      runCommand "unpack-${name}-${version}" {}
-      ''
-        mkdir -p $out
-        tar -xzf ${crate} -C $out
-        echo '{"package":"${sha256}","files":{}}' > $out/${name}-${version}/.cargo-checksum.json
+          runHook postCheck
+        '';
+
+
+      docPhase = lib.optionalString doDoc ''
+        runHook preDoc
+
+        logRun cargo doc --offline "''${cargo_release[*]}" || ${if doDocFail then "false" else "true" }
+
+        ${lib.optionalString removeReferencesToSrcFromDocs ''
+        # Remove references to the source derivation to reduce closure size
+              match='<meta name="description" content="Source to the Rust file `${builtins.storeDir}[^`]*`.">'
+        replacement='<meta name="description" content="Source to the Rust file removed to reduce Nix closure size.">'
+        find target/doc -name "*\.rs\.html" -exec sed -i "s|$match|$replacement|" {} +
+        ''}
+
+        runHook postDoc
       '';
-  };
-if isNull override then drv else drv.overrideAttrs override
+
+      installPhase =
+        ''
+          runHook preInstall
+
+          ${lib.optionalString copyBins ''
+          if [ -d out ]; then
+            mkdir -p $out/bin
+            find out -type f -executable -exec cp {} $out/bin \;
+          fi
+          ''}
+
+          ${lib.optionalString copyTarget ''
+          mkdir -p $out
+          ${if compressTarget then
+          ''
+          tar -c target | ${zstd}/bin/zstd -o $out/target.tar.zst
+          '' else
+          ''
+          cp -r target $out
+          ''}
+          ''}
+
+          ${lib.optionalString (doDoc && copyDocsToSeparateOutput) ''
+          cp -r target/doc $doc
+          ''}
+
+          runHook postInstall
+        '';
+      passthru = {
+        # Handy for debugging
+        inherit builtDependencies;
+      };
+    }
+    )
+    ;
+
+  # XXX: the actual crate format is not documented but in practice is a
+  # gzipped tar; we simply unpack it and introduce a ".cargo-checksum.json"
+  # file that cargo itself uses to double check the sha256
+  unpackCrate = name: version: sha256:
+    with
+    { crate = builtins.fetchurl
+        { url = "https://crates.io/api/v1/crates/${name}/${version}/download";
+          inherit sha256;
+        };
+    };
+    runCommand "unpack-${name}-${version}" {}
+    ''
+      mkdir -p $out
+      tar -xzf ${crate} -C $out
+      echo '{"package":"${sha256}","files":{}}' > $out/${name}-${version}/.cargo-checksum.json
+    '';
+in
+drv.overrideAttrs override

--- a/config.nix
+++ b/config.nix
@@ -92,4 +92,26 @@ rec
   cargoTestCommands = attrs.cargoTestCommands or [
     ''cargo test "''${cargo_release}" -j $NIX_BUILD_CORES''
   ];
+
+  override = attrs.override or (x: x);
+
+  release = attrs.release or true;
+
+  #| Whether or not to forward intermediate build artifacts to $out
+  copyTarget = attrs.copyTarget or false;
+
+  #| Whether or not the rustdoc can fail the build
+  doDocFail = attrs.doDocFail or false;
+
+  doDoc = attrs.doDoc or true;
+
+  copyBins = attrs.copyBins or true;
+
+  copyDocsToSeparateOutput = attrs.copyDocsToSeparateOutput or true;
+
+  removeReferencesToSrcFromDocs = attrs.removeReferencesToSrcFromDocs or true;
+
+  doCheck = attrs.doCheck or true;
+
+  buildInputs = attrs.buildInputs or [];
 }

--- a/config.nix
+++ b/config.nix
@@ -1,0 +1,95 @@
+{ lib, libb, builtinz, src, attrs }:
+rec
+{ usePureFromTOML = attrs.usePureFromTOML or true;
+  readTOML = builtinz.readTOML usePureFromTOML;
+
+  compressTarget = attrs.compressTarget or true;
+
+  # Whether we skip pre-building the deps
+  isSingleStep = attrs.singleStep or false;
+
+  # The members we want to build
+  # (list of directory names)
+  wantedMembers =
+    lib.mapAttrsToList (member: _cargotoml: member) wantedMemberCargotomls;
+
+  # Member path to cargotoml
+  # (attrset from directory name to Nix object)
+  wantedMemberCargotomls =
+    let pred =
+      if ! isWorkspace
+      then (_member: _cargotoml: true)
+      else
+        if builtins.hasAttr "targets" attrs
+        then (_member: cargotoml: lib.elem cargotoml.package.name attrs.targets)
+        else (member: _cargotoml: member != "."); in
+    lib.filterAttrs pred cargotomls;
+
+  # All cargotomls, from path to nix object
+  # (attrset from directory name to Nix object)
+  cargotomls =
+    let readTOML = builtinz.readTOML usePureFromTOML; in
+
+    { "." = toplevelCargotoml; } //
+    lib.optionalAttrs isWorkspace
+    (lib.listToAttrs
+      (map
+        (member:
+          { name = member;
+            value = readTOML (src + "/${member}/Cargo.toml");
+          }
+        )
+        (toplevelCargotoml.workspace.members or [])
+      )
+    );
+
+  patchedSources =
+    let
+      mkRelative = po:
+        if lib.hasPrefix "/" po.path
+        then throw "'${toString src}/Cargo.toml' contains the absolute path '${toString po.path}' which is not allowed under a [patch] section by naersk. Please make it relative to '${toString src}'"
+        else src + "/" + po.path;
+    in lib.optionals (builtins.hasAttr "patch" toplevelCargotoml)
+        (map mkRelative
+          (lib.collect (as: lib.isAttrs as && builtins.hasAttr "path" as)
+            toplevelCargotoml.patch));
+
+  # Are we building a workspace (or is this a simple crate) ?
+  isWorkspace = builtins.hasAttr "workspace" toplevelCargotoml;
+
+  # The top level Cargo.toml, either a workspace or package
+  toplevelCargotoml = readTOML (src + "/Cargo.toml");
+
+  # The cargo lock
+  cargolock = readTOML (src + "/Cargo.lock");
+
+  # The list of paths to Cargo.tomls. If this is a workspace, the paths
+  # are the members. Otherwise, there is a single path, ".".
+  cratePaths = lib.concatStringsSep "\n" wantedMembers;
+
+  packageName = attrs.name or toplevelCargotoml.package.name or
+    (if isWorkspace then "rust-workspace" else "rust-package");
+
+  packageVersion = attrs.version or toplevelCargotoml.package.version or
+    "unknown";
+
+  # The list of _all_ crates (incl. transitive dependencies) with name,
+  # version and sha256 of the crate
+  # Example:
+  #   [ { name = "wabt", version = "2.0.6", sha256 = "..." } ]
+  crateDependencies = libb.mkVersions cargolock;
+
+  preBuild = ''
+    # Cargo uses mtime, and we write `src/lib.rs` and `src/main.rs`in
+    # the dep build step, so make sure cargo rebuilds stuff
+    if [ -f src/lib.rs ] ; then touch src/lib.rs; fi
+    if [ -f src/main.rs ] ; then touch src/main.rs; fi
+  '';
+
+  cargoBuild = attrs.cargoBuild or ''
+    cargo build "''${cargo_release}" -j $NIX_BUILD_CORES -Z unstable-options --out-dir out
+  '';
+  cargoTestCommands = attrs.cargoTestCommands or [
+    ''cargo test "''${cargo_release}" -j $NIX_BUILD_CORES''
+  ];
+}

--- a/default.nix
+++ b/default.nix
@@ -39,49 +39,47 @@ let
         { inherit lib writeText remarshal runCommand ; }; in
 
 # Crate building
-with rec
-  {
-      mkConfig = src: attrs:
-        import ./config.nix { inherit lib src attrs libb builtinz; };
-      buildPackage = src: attrs:
-        let config = (mkConfig src attrs); in
-        import ./build.nix src
-          (defaultBuildAttrs //
-            { pname = config.packageName;
-              version = config.packageVersion;
-              inherit (config) cratePaths crateDependencies preBuild cargoBuild cargoTestCommands compressTarget;
-            } //
-            (removeAttrs attrs [ "usePureFromTOML" "cargotomls" "singleStep" ]) //
-            { builtDependencies = lib.optional (! config.isSingleStep)
-                (
-                  import ./build.nix
-                  (libb.dummySrc
-                    { cargoconfig =
-                        if builtinz.pathExists (toString src + "/.cargo/config")
-                        then builtins.readFile (src + "/.cargo/config")
-                        else null;
-                      cargolock = config.cargolock;
-                      cargotomls = config.cargotomls;
-                      inherit (config) patchedSources;
-                    }
-                  )
-                  (defaultBuildAttrs //
-                    { pname = "${config.packageName}-deps";
-                      version = config.packageVersion;
-                      inherit (config) cratePaths crateDependencies cargoBuild compressTarget;
-                    } //
-                  (removeAttrs attrs [ "usePureFromTOML" "cargotomls"  "singleStep"]) //
-                  { preBuild = "";
-                    cargoTestCommands = map (cmd: "${cmd} || true") config.cargoTestCommands;
-                    copyTarget = true;
-                    copyBins = false;
-                    copyDocsToSeparateOutput = false;
-                  }
-                  )
-                );
-            });
-  };
-
+let
+  mkConfig = src: attrs:
+    import ./config.nix { inherit lib src attrs libb builtinz; };
+  buildPackage = src: attrs:
+    let config = (mkConfig src attrs); in
+    import ./build.nix src
+      (defaultBuildAttrs //
+        { pname = config.packageName;
+          version = config.packageVersion;
+          inherit (config) cratePaths crateDependencies preBuild cargoBuild cargoTestCommands compressTarget;
+        } //
+        (removeAttrs attrs [ "usePureFromTOML" "cargotomls" "singleStep" ]) //
+        { builtDependencies = lib.optional (! config.isSingleStep)
+            (
+              import ./build.nix
+              (libb.dummySrc
+                { cargoconfig =
+                    if builtinz.pathExists (toString src + "/.cargo/config")
+                    then builtins.readFile (src + "/.cargo/config")
+                    else null;
+                  cargolock = config.cargolock;
+                  cargotomls = config.cargotomls;
+                  inherit (config) patchedSources;
+                }
+              )
+              (defaultBuildAttrs //
+                { pname = "${config.packageName}-deps";
+                  version = config.packageVersion;
+                  inherit (config) cratePaths crateDependencies cargoBuild compressTarget;
+                } //
+              (removeAttrs attrs [ "usePureFromTOML" "cargotomls"  "singleStep"]) //
+              { preBuild = "";
+                cargoTestCommands = map (cmd: "${cmd} || true") config.cargoTestCommands;
+                copyTarget = true;
+                copyBins = false;
+                copyDocsToSeparateOutput = false;
+              }
+              )
+            );
+        });
+in
 {
   inherit buildPackage;
 }

--- a/default.nix
+++ b/default.nix
@@ -41,111 +41,18 @@ let
 # Crate building
 with rec
   {
-      commonAttrs = src: attrs: rec
-        { usePureFromTOML = attrs.usePureFromTOML or true;
-          readTOML = builtinz.readTOML usePureFromTOML;
-
-          compressTarget = attrs.compressTarget or true;
-
-          # Whether we skip pre-building the deps
-          isSingleStep = attrs.singleStep or false;
-
-          # The members we want to build
-          # (list of directory names)
-          wantedMembers =
-            lib.mapAttrsToList (member: _cargotoml: member) wantedMemberCargotomls;
-
-          # Member path to cargotoml
-          # (attrset from directory name to Nix object)
-          wantedMemberCargotomls =
-            let pred =
-              if ! isWorkspace
-              then (_member: _cargotoml: true)
-              else
-                if builtins.hasAttr "targets" attrs
-                then (_member: cargotoml: lib.elem cargotoml.package.name attrs.targets)
-                else (member: _cargotoml: member != "."); in
-            lib.filterAttrs pred cargotomls;
-
-          # All cargotomls, from path to nix object
-          # (attrset from directory name to Nix object)
-          cargotomls =
-            let readTOML = builtinz.readTOML usePureFromTOML; in
-
-            { "." = toplevelCargotoml; } //
-            lib.optionalAttrs isWorkspace
-            (lib.listToAttrs
-              (map
-                (member:
-                  { name = member;
-                    value = readTOML (src + "/${member}/Cargo.toml");
-                  }
-                )
-                (toplevelCargotoml.workspace.members or [])
-              )
-            );
-
-          patchedSources =
-            let
-              mkRelative = po:
-                if lib.hasPrefix "/" po.path
-                then throw "'${toString src}/Cargo.toml' contains the abolsute path '${toString po.path}' which is not allowed under a [patch] section by naersk. Please make it relative to '${toString src}'"
-                else src + "/" + po.path;
-            in lib.optionals (builtins.hasAttr "patch" toplevelCargotoml)
-                (map mkRelative
-                  (lib.collect (as: lib.isAttrs as && builtins.hasAttr "path" as)
-                    toplevelCargotoml.patch));
-
-          # Are we building a workspace (or is this a simple crate) ?
-          isWorkspace = builtins.hasAttr "workspace" toplevelCargotoml;
-
-          # The top level Cargo.toml, either a workspace or package
-          toplevelCargotoml = readTOML (src + "/Cargo.toml");
-
-          # The cargo lock
-          cargolock = readTOML (src + "/Cargo.lock");
-
-          # The list of paths to Cargo.tomls. If this is a workspace, the paths
-          # are the members. Otherwise, there is a single path, ".".
-          cratePaths = lib.concatStringsSep "\n" wantedMembers;
-
-          packageName = attrs.name or toplevelCargotoml.package.name or
-            (if isWorkspace then "rust-workspace" else "rust-package");
-
-          packageVersion = attrs.version or toplevelCargotoml.package.version or
-            "unknown";
-
-          # The list of _all_ crates (incl. transitive dependencies) with name,
-          # version and sha256 of the crate
-          # Example:
-          #   [ { name = "wabt", version = "2.0.6", sha256 = "..." } ]
-          crateDependencies = libb.mkVersions cargolock;
-
-          preBuild = ''
-            # Cargo uses mtime, and we write `src/lib.rs` and `src/main.rs`in
-            # the dep build step, so make sure cargo rebuilds stuff
-            if [ -f src/lib.rs ] ; then touch src/lib.rs; fi
-            if [ -f src/main.rs ] ; then touch src/main.rs; fi
-          '';
-
-          cargoBuild = attrs.cargoBuild or ''
-            cargo build "''${cargo_release}" -j $NIX_BUILD_CORES -Z unstable-options --out-dir out
-          '';
-          cargoTestCommands = attrs.cargoTestCommands or [
-            ''cargo test "''${cargo_release}" -j $NIX_BUILD_CORES''
-          ];
-        };
-
+      mkConfig = src: attrs:
+        import ./config.nix { inherit lib src attrs libb builtinz; };
       buildPackage = src: attrs:
-        with (commonAttrs src attrs);
+        let config = (mkConfig src attrs); in
         import ./build.nix src
           (defaultBuildAttrs //
-            { pname = packageName;
-              version = packageVersion;
-              inherit cratePaths crateDependencies preBuild cargoBuild cargoTestCommands compressTarget;
+            { pname = config.packageName;
+              version = config.packageVersion;
+              inherit (config) cratePaths crateDependencies preBuild cargoBuild cargoTestCommands compressTarget;
             } //
-            (removeAttrs attrs [ "targets" "usePureFromTOML" "cargotomls" "singleStep" ]) //
-            { builtDependencies = lib.optional (! isSingleStep)
+            (removeAttrs attrs [ "usePureFromTOML" "cargotomls" "singleStep" ]) //
+            { builtDependencies = lib.optional (! config.isSingleStep)
                 (
                   import ./build.nix
                   (libb.dummySrc
@@ -153,19 +60,19 @@ with rec
                         if builtinz.pathExists (toString src + "/.cargo/config")
                         then builtins.readFile (src + "/.cargo/config")
                         else null;
-                      cargolock = cargolock;
-                      cargotomls = cargotomls;
-                      inherit patchedSources;
+                      cargolock = config.cargolock;
+                      cargotomls = config.cargotomls;
+                      inherit (config) patchedSources;
                     }
                   )
                   (defaultBuildAttrs //
-                    { pname = "${packageName}-deps";
-                      version = packageVersion;
-                      inherit cratePaths crateDependencies cargoBuild compressTarget;
+                    { pname = "${config.packageName}-deps";
+                      version = config.packageVersion;
+                      inherit (config) cratePaths crateDependencies cargoBuild compressTarget;
                     } //
-                  (removeAttrs attrs [ "targets" "usePureFromTOML" "cargotomls"  "singleStep"]) //
+                  (removeAttrs attrs [ "usePureFromTOML" "cargotomls"  "singleStep"]) //
                   { preBuild = "";
-                    cargoTestCommands = map (cmd: "${cmd} || true") cargoTestCommands;
+                    cargoTestCommands = map (cmd: "${cmd} || true") config.cargoTestCommands;
                     copyTarget = true;
                     copyBins = false;
                     copyDocsToSeparateOutput = false;

--- a/default.nix
+++ b/default.nix
@@ -12,10 +12,8 @@
 , zstd
 }:
 
-with
-  { libb = import ./lib.nix { inherit lib writeText runCommand remarshal; }; };
-
 let
+  libb = import ./lib.nix { inherit lib writeText runCommand remarshal; };
   defaultBuildAttrs =
       { inherit
           jq
@@ -30,14 +28,12 @@ let
           cargo
           rustc
           zstd;
-      }; in
-
-let
+      };
   builtinz =
       builtins //
       import ./builtins
-        { inherit lib writeText remarshal runCommand ; }; in
-
+        { inherit lib writeText remarshal runCommand ; };
+in
 # Crate building
 let
   mkConfig = src: attrs:
@@ -48,7 +44,7 @@ let
       (defaultBuildAttrs //
         { pname = config.packageName;
           version = config.packageVersion;
-          inherit (config) cratePaths crateDependencies preBuild cargoBuild cargoTestCommands compressTarget;
+          inherit (config) cratePaths crateDependencies preBuild cargoBuild cargoTestCommands compressTarget override release copyTarget doDocFail doDoc copyBins copyDocsToSeparateOutput removeReferencesToSrcFromDocs doCheck buildInputs;
         } //
         (removeAttrs attrs [ "usePureFromTOML" "cargotomls" "singleStep" ]) //
         { builtDependencies = lib.optional (! config.isSingleStep)
@@ -67,7 +63,7 @@ let
               (defaultBuildAttrs //
                 { pname = "${config.packageName}-deps";
                   version = config.packageVersion;
-                  inherit (config) cratePaths crateDependencies cargoBuild compressTarget;
+                  inherit (config) cratePaths crateDependencies cargoBuild compressTarget override release doDocFail doDoc removeReferencesToSrcFromDocs doCheck buildInputs;
                 } //
               (removeAttrs attrs [ "usePureFromTOML" "cargotomls"  "singleStep"]) //
               { preBuild = "";
@@ -75,11 +71,9 @@ let
                 copyTarget = true;
                 copyBins = false;
                 copyDocsToSeparateOutput = false;
+                builtDependencies = [];
               }
               )
             );
         });
-in
-{
-  inherit buildPackage;
-}
+in { inherit buildPackage; }


### PR DESCRIPTION
The code had gotten so hairy I couldn't follow anymore. This splits out the configuration in its own file, and differentiates the configuration that's used during the build vs. the configuration that's used when planning the build.