### PR TITLE
Fix evaluation for restrict-eval

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -48,6 +48,7 @@
 , remarshal
 , crateDependencies
 , zstd
+, fetchurl
 }:
 
 let
@@ -214,7 +215,7 @@ let
   # file that cargo itself uses to double check the sha256
   unpackCrate = name: version: sha256:
     let
-      crate = builtins.fetchurl {
+      crate = fetchurl {
         url = "https://crates.io/api/v1/crates/${name}/${version}/download";
         inherit sha256;
       };

--- a/builtins/default.nix
+++ b/builtins/default.nix
@@ -39,7 +39,7 @@ rec
   # TODO: use `builtins.pathExists` once
   # https://github.com/NixOS/nix/pull/3012 has landed and is generally
   # available
-  pathExists = path:
+  pathExists = if lib.versionAtLeast builtins.nixVersion "2.3" then builtins.pathExists else path:
     let
       all = lib.all (x: x);
       isOk = part:

--- a/default.nix
+++ b/default.nix
@@ -66,8 +66,8 @@ let
                     {
                       src = libb.dummySrc {
                         cargoconfig =
-                          if builtinz.pathExists (toString config.src + "/.cargo/config")
-                          then builtins.readFile (config.src + "/.cargo/config")
+                          if builtinz.pathExists (toString config.root + "/.cargo/config")
+                          then builtins.readFile (config.root + "/.cargo/config")
                           else null;
                         cargolock = config.cargolock;
                         cargotomls = config.cargotomls;

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@
 , cargo
 , rustc
 , zstd
+, fetchurl
 }:
 
 let
@@ -29,6 +30,7 @@ let
       cargo
       rustc
       zstd
+      fetchurl
       ;
   };
 

--- a/test.nix
+++ b/test.nix
@@ -87,12 +87,12 @@ rec
     "my-bin > $out";
 
   workspace = naersk.buildPackage {
-    src = pkgs.lib.cleanSource ./test/workspace;
+    src = ./test/workspace;
     doDoc = false;
   };
 
   workspace-patched = naersk.buildPackage {
-    src = pkgs.lib.cleanSource ./test/workspace-patched;
+    src = ./test/workspace-patched;
     doDoc = false;
   };
 


### PR DESCRIPTION
* Don't make use of builtins.fetchurl but use nixpkgs'
* Use the `pathExists` builtin when possible, the custom one is a bit greedy
* Fetch the `Cargo.lock` and others from an unfiltered source (`root`)