### PR TITLE
Disable doDoc by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ it is converted to an attribute set equivalent to `{ root = theArg; }`.
 | `cargoTestCommands` | The commands to run in the `checkPhase`. Default: `[ ''cargo "''${cargo_options[@]}" test "''${cargo_release[@]}" -j $NIX_BUILD_CORES'' ]` |
 | `buildInputs` | Extra `buildInputs` to all derivations. Default: `[]` |
 | `cargoOptions` | Options passed to cargo before the command (cargo OPTIONS <cmd>) Default: `[]` |
-| `doDoc` | When true, `cargo doc` is run and a new output `doc` is generated. Default: `true` |
+| `doDoc` | When true, `cargo doc` is run and a new output `doc` is generated. Default: `false` |
 | `release` | When true, all cargo builds are run with `--release`. Default: `true` |
 | `override` | An override for all derivations involved in the build. Default: `(x: x)` |
 | `singleStep` | When true, no intermediary (dependency-only) build is run. Enabling `singleStep` greatly reduces the incrementality of the builds. Default: `false` |

--- a/config.nix
+++ b/config.nix
@@ -25,7 +25,7 @@ let
       # Options passed to cargo before the command (cargo OPTIONS <cmd>)
       cargoOptions = attrs0.cargoOptions or [];
       # When true, `cargo doc` is run and a new output `doc` is generated.
-      doDoc = attrs0.doDoc or true;
+      doDoc = attrs0.doDoc or false;
       # When true, all cargo builds are run with `--release`.
       release = attrs0.release or true;
       # An override for all derivations involved in the build.

--- a/test.nix
+++ b/test.nix
@@ -16,7 +16,6 @@ rec
     '';
 
   docparse = naersk.buildPackage {
-    doDoc = false;
     doCheck = false;
     root = ./docparse;
     src = builtins.filterSource (
@@ -89,7 +88,6 @@ rec
   # "targets" is broken
   #lucet = naersk.buildPackage lucetSrc
   #{ nativeBuildInputs = [ pkgs.cmake pkgs.python3 ] ;
-  #doDoc = false;
   #doCheck = false;
   #targets =
   #[ "lucetc"
@@ -107,6 +105,11 @@ rec
 
   simple-dep = naersk.buildPackage ./test/simple-dep;
 
+  simple-dep-doc = naersk.buildPackage
+    { src = ./test/simple-dep;
+      doDoc = true;
+    };
+
   simple-dep-patched = naersk.buildPackage ./test/simple-dep-patched;
 
   dummyfication = naersk.buildPackage ./test/dummyfication;
@@ -120,15 +123,14 @@ rec
     cargoOptions = [ "--locked" ];
   };
 
-  workspace = naersk.buildPackage {
-    src = ./test/workspace;
-    doDoc = false;
-  };
+  workspace = naersk.buildPackage ./test/workspace;
 
-  workspace-patched = naersk.buildPackage {
-    src = ./test/workspace-patched;
-    doDoc = false;
-  };
+  workspace-patched = naersk.buildPackage ./test/workspace-patched;
+
+  workspace-doc = naersk.buildPackage
+    { src = ./test/workspace;
+      doDoc = true;
+    };
 
   # Fails with some remarshal error
   #servo = naersk.buildPackage


### PR DESCRIPTION
The documentation building step takes a fair bit of time and most users
won't care about it. By default we turn it off.