### PR TITLE
Basic flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docparse/target
+/flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Build rust crates in Nix. No configuration, no code generation. IFD and sandbox friendly.";
+
+  edition = 201909;
+
+  outputs = { self, nixpkgs }: let
+    forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
+  in {
+    # Naersk is not a package, not an app, not a module... It's just a Library
+    lib = forAllSystems (system: nixpkgs.legacyPackages."${system}".callPackage ./default.nix {});
+  };
+}


### PR DESCRIPTION
This allows you to use naersk more easily via the current version of [nix-flakes](https://youtu.be/UeBX7Ide5a0) (though it may rapidly change syntax, maybe it should be on its own branch for now) :)  
Btw, I saw your speech on NixCon via YouTube, it's really good!

Before:

```nix
{
  inputs.naersk = {
    url   = "github:nmattia/naersk";
    flake = false;
  };

  # Further down, inside outputs:
  packages = forAllSystems (system: {
    rnix-lsp = let
      naerskBuilt  = nixpkgs.legacyPackages."${system}".callPackage naersk {};
    in naerskBuilt.buildPackage {
      name = "rnix-lsp";
      src  = cleanSourceSomehow ./.;
      root = ./.;
    };
  });
}
```

After:

```nix
{
  inputs.naersk = {
    url   = "github:nmattia/naersk";
  };

  # Further down, inside outputs:
  packages = forAllSystems (system: {
    rnix-lsp = naersk.lib."${system}".buildPackage {
      name = "rnix-lsp";
      src  = cleanSourceSomehow ./.;
      root = ./.;
    };
  });
}
```