### PR TITLE
Fix failure to `cat` out.json when `cargo` errors

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -252,7 +252,7 @@ let
 
         if [ "$cargo_ec" -ne "0" ]
         then
-          cat out.json | jq -cMr 'select(.message.rendered != null) | .message.rendered'
+          cat $cargo_build_output_json | jq -cMr 'select(.message.rendered != null) | .message.rendered'
           log "cargo returned with exit code $cargo_ec, exiting"
           exit "$cargo_ec"
         fi


### PR DESCRIPTION
out.json will never exist because we make a temporary file stored in
`$cargo_build_output_json`.

---

In #62, the `cargo build` errors were redirected to a `$cargo_build_output_json` file, but when attempting to retrieve these errors, tried to `cat` out.json (which never existed).