### PR TITLE
Fix too big environment variable `paths` in `symLinkJoin`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 { lib
 , runCommand
-, symlinkJoin
 , stdenv
 , writeText
 , jq
@@ -11,6 +10,7 @@
 , rustc
 , zstd
 , fetchurl
+, lndir
 }:
 
 let
@@ -26,11 +26,11 @@ let
       stdenv
       rsync
       remarshal
-      symlinkJoin
       cargo
       rustc
       zstd
       fetchurl
+      lndir
       ;
   };
 


### PR DESCRIPTION
When there are too many crate dependencies the `crates.io` derivation will fail with:

```
while setting up the build environment: executing '/nix/store/rm1hz1lybxangc8sdl7xvzs5dcvigvf7-bash-4.4-p23/bin/bash': Argument list too long
builder for '/nix/store/pbbnw6y6zggqddy244ix5nyysamcgm0j-crates-io.drv' failed with exit code 1
```

This is caused by the [`paths` environment variable of `symlinkJoin`](https://github.com/NixOS/nixpkgs/blob/fc592a52cacfbf5f22e6479a22263983f5346ea6/pkgs/build-support/trivial-builders.nix#L250) exceeding the limit.

This is fixed by having our own version of `symlinkJoin` called `symlinkJoinPassViaFile` which passes `paths` via a file instead of via an environment variable.

I think this should be fixed in the upstream `symlinkJoin` so I'll provide a PR for that in `nixpkgs`. But until that lands we should have this fix here.