### PR TITLE
Set the cargo test option --test-threads to $NIX_BUILD_CORES

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -7,6 +7,7 @@
 , #| What command to run during the test phase
   cargoTestCommands
 , cargoTestOptions
+, cargoTestArguments
 , copyTarget
   #| Whether or not to compress the target when copying it
 , compressTarget
@@ -192,6 +193,7 @@ let
     cargo_options = cargoOptions;
     cargo_build_options = cargoBuildOptions;
     cargo_test_options = cargoTestOptions;
+    cargo_test_arguments = cargoTestArguments;
     cargo_bins_jq_filter = copyBinsFilter;
 
     configurePhase = ''
@@ -224,6 +226,7 @@ let
       log "cargo_options: $cargo_options"
       log "cargo_build_options: $cargo_build_options"
       log "cargo_test_options: $cargo_test_options"
+      log "cargo_test_arguments: $cargo_test_arguments"
       log "cargo_bins_jq_filter: $cargo_bins_jq_filter"
       log "cargo_build_output_json (created): $cargo_build_output_json"
       log "crate_sources: $crate_sources"

--- a/config.nix
+++ b/config.nix
@@ -49,7 +49,9 @@ let
     # The commands to run in the `checkPhase`. Do not forget to set
     # [`doCheck`](https://nixos.org/nixpkgs/manual/#ssec-check-phase).
     cargoTestCommands =
-      allowFun attrs0 "cargoTestCommands" [ ''cargo $cargo_options test $cargo_test_options'' ];
+      allowFun attrs0 "cargoTestCommands" [
+        ''cargo $cargo_options test $cargo_test_options ''${cargo_test_arguments:+-- $cargo_test_arguments}''
+      ];
 
     # Options passed to cargo test, i.e. `cargo test <OPTS>`. These options
     # can be accessed during the build through the environment variable
@@ -58,6 +60,12 @@ let
     # environment variables but must be careful when introducing e.g. spaces. <br/>
     cargoTestOptions =
       allowFun attrs0 "cargoTestOptions" [ "$cargo_release" ''-j "$NIX_BUILD_CORES"'' ];
+
+    # Arguments passed to the test binary, i.e. `--test-threads=...`. These
+    # arguments can be accessed during the build through the environment
+    # variable `cargo_test_arguments`.
+    cargoTestArguments =
+      allowFun attrs0 "cargoTestArguments" [ ''--test-threads="$NIX_BUILD_CORES"'' ];
 
     # Extra `buildInputs` to all derivations.
     buildInputs = attrs0.buildInputs or [];
@@ -187,6 +195,7 @@ let
 
       cargoTestCommands
       cargoTestOptions
+      cargoTestArguments
 
       doDoc
       doDocFail


### PR DESCRIPTION
Because it defaults to the number of cores which is often too much parallelism.