### PR TITLE
Make sure `expandMember` works with a trailing slash

### DIFF
--- a/.github/actions/nix/install-nix
+++ b/.github/actions/nix/install-nix
@@ -62,7 +62,7 @@ save_cache() {
     echo "Using cache '$cachix_cache' for '$GITHUB_REPOSITORY'"
 
     set +x
-    if [ -z "${CACHIX_SIGNING_KEY:-}" ] && [ -n "${INPUT_CACHIX_SIGNING_KEY:-}" ]; then
+    if [ -z "${CACHIX_SIGNING_KEY:=}" ] && [ -n "${INPUT_CACHIX_SIGNING_KEY:-}" ]; then
         echo "CACHIX_SIGNING_KEY not set, but INPUT_CACHIX_SIGNING_KEY is present"
         echo "setting CACHIX_SIGNING_KEY"
         export CACHIX_SIGNING_KEY="$INPUT_CACHIX_SIGNING_KEY"

--- a/config.nix
+++ b/config.nix
@@ -258,7 +258,7 @@ let
         # this turns members like "foo/*" into [ "foo/bar" "foo/baz" ]
         # as in https://github.com/rust-analyzer/rust-analyzer/blob/b2ed130ffd9c79de26249a1dfb2a8312d6af12b3/Cargo.toml#L2
         expandMember = member:
-          if lib.hasInfix "*" member
+          if (lib.hasSuffix "/*" member) || (lib.hasSuffix "/*/" member)
           then
             let
               rootDir = lib.replaceStrings [ "/*/" "/*" ] [ "" "" ] member;

--- a/test/cargo-wildcard/Cargo.toml
+++ b/test/cargo-wildcard/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = [ "crates/*" ]
+members = [ "crates/*", "crates/*/" ]


### PR DESCRIPTION
I ran across this issue when trying to build [nushell](https://github.com/nushell/nushell/tree/1ec2ec72b5d772db8759905e03cb34b6409f5067). Their [Cargo.toml](https://github.com/nushell/nushell/blob/1ec2ec72b5d772db8759905e03cb34b6409f5067/Cargo.toml#L16) has a trailing slash in the globbing pattern, which breaks naersk with the same error seen in #53 

This fix addresses that specific issue, however the `members` field actually accepts a much more extensive [globbing syntax](https://docs.rs/glob/0.3.0/glob/struct.Pattern.html), at least according to the docs.

I'm hoping that more involved cases are relatively rare in practice. If anyone has a more extensive/less error-prone way of handling this, please do!