### PR TITLE
Handle documentation for different targets

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -325,7 +325,7 @@ let
       # Remove references to the source derivation to reduce closure size
             match='<meta name="description" content="Source to the Rust file `${builtins.storeDir}[^`]*`.">'
       replacement='<meta name="description" content="Source to the Rust file removed to reduce Nix closure size.">'
-      find target/doc -name "*\.rs\.html" -exec sed -i "s|$match|$replacement|" {} +
+      find target/doc ''${CARGO_BUILD_TARGET:+target/$CARGO_BUILD_TARGET/doc} -name "*\.rs\.html" -exec sed -i "s|$match|$replacement|" {} +
     ''}
 
       runHook postDoc
@@ -367,6 +367,9 @@ let
 
         ${lib.optionalString (doDoc && copyDocsToSeparateOutput) ''
         cp -r target/doc $doc
+        if [[ -n "$CARGO_BUILD_TARGET" && -d "target/$CARGO_BUILD_TARGET/doc" ]]; then
+          cp -r target/$CARGO_BUILD_TARGET/doc/. $doc/
+        fi
       ''}
 
         runHook postInstall


### PR DESCRIPTION
When cargo is instructed to build code for a different target, it will store the
output under `target/<host-triple>`. This means that some docs will be under
`target/<triple>/doc` and some under `target/doc`.

This change takes into the account the existence of `CARGO_BUILD_TARGET` and
uses that to discover newly created docs when copying/processing.