### PR TITLE
Avoid key collision in git dependencies

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -106,15 +106,15 @@ let
             || true)
           if [ -n "$name" ]; then
             # Most filesystmes have a maximum filename length of 255
-            key="$(echo "$name-$key" | head -c 255)"
-            log "$url Found crate '$name' ($key)"
-            if [ -d "$out/$key" ]; then
-              log "Crate was already unpacked at $out/$key"
+            nkey="$(echo "$name-$key" | head -c 255)"
+            log "$url Found crate '$name' ($nkey)"
+            if [ -d "$out/$nkey" ]; then
+              log "Crate was already unpacked at $out/$nkey"
             else
-              cp -r $(dirname $toml) $out/$key
-              chmod +w "$out/$key"
-              echo '{"package":null,"files":{}}' > $out/$key/.cargo-checksum.json
-              log "Crate unpacked at $out/$key"
+              cp -r $(dirname $toml) $out/$nkey
+              chmod +w "$out/$nkey"
+              echo '{"package":null,"files":{}}' > $out/$nkey/.cargo-checksum.json
+              log "Crate unpacked at $out/$nkey"
             fi
           fi
         done <<< "$tomls"

--- a/build.nix
+++ b/build.nix
@@ -1,5 +1,4 @@
 { src
-, preBuild
   #| What command to run during the build phase
 , cargoBuild
 , cargoBuildOptions
@@ -135,7 +134,6 @@ let
     inherit
       src
       version
-      preBuild
       remapPathPrefix
       ;
 

--- a/build.nix
+++ b/build.nix
@@ -104,10 +104,15 @@ let
             | grep -m 1 "^name\W" \
             | grep -oP '(?<=").+(?=")' \
             || true)
-          if [ -n "$name" ]; then
+          version=$(cat $toml \
+            | sed -n -e '/\[package\]/,$p' \
+            | grep -m 1 "^version\W" \
+            | grep -oP '(?<=").+(?=")' \
+            || true)
+          if [ -n "$name" -a -n "$version" ]; then
             # Most filesystmes have a maximum filename length of 255
-            nkey="$(echo "$name-$key" | head -c 255)"
-            log "$url Found crate '$name' ($nkey)"
+            nkey="$(echo "$name-$version-$key" | head -c 255)"
+            log "$url Found crate '$name-$version' ($nkey)"
             if [ -d "$out/$nkey" ]; then
               log "Crate was already unpacked at $out/$nkey"
             else


### PR DESCRIPTION
I don't know if this was the original intended behavior or not, but since `$key` (i.e. the git rev) is originally placed at the end of the directory name, long enough keys mean it eventually gets truncated altogether. In this case it's breaking having dependencies on two different git checkouts of bytecodealliance/wasmtime.