### PR TITLE
Make top-level override easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ it is converted to an attribute set equivalent to `{ root = theArg; }`.
 | `doDoc` | When true, `cargo doc` is run and a new output `doc` is generated. Default: `false` |
 | `release` | When true, all cargo builds are run with `--release`. The environment variable `cargo_release` is set to `--release` iff this option is set. Default: `true` |
 | `override` | An override for all derivations involved in the build. Default: `(x: x)` |
+| `overrideMain` | An override for the top-level (last, main) derivation. If both `override` and `overrideMain` are specified, _both_ will be applied to the top-level derivation. Default: `(x: x)` |
 | `singleStep` | When true, no intermediary (dependency-only) build is run. Enabling `singleStep` greatly reduces the incrementality of the builds. Default: `false` |
 | `targets` | The targets to build if the `Cargo.toml` is a virtual manifest. |
 | `copyBins` | When true, the resulting binaries are copied to `$out/bin`. <br/> Note: this relies on cargo's `--message-format` argument, set in the default `cargoBuildOptions`. Default: `true` |

--- a/config.nix
+++ b/config.nix
@@ -80,6 +80,12 @@ let
     release = attrs0.release or true;
     # An override for all derivations involved in the build.
     override = attrs0.override or (x: x);
+
+    # An override for the top-level (last, main) derivation. If both `override`
+    # and `overrideMain` are specified, _both_ will be applied to the top-level
+    # derivation.
+    overrideMain = attrs0.overrideMain or (x: x);
+
     # When true, no intermediary (dependency-only) build is run. Enabling
     # `singleStep` greatly reduces the incrementality of the builds.
     singleStep = attrs0.singleStep or false;
@@ -227,6 +233,8 @@ let
     inherit (sr) src root;
     # Whether we skip pre-building the deps
     isSingleStep = attrs.singleStep;
+
+    inherit (attrs) overrideMain;
 
     # The members we want to build
     # (list of directory names)

--- a/default.nix
+++ b/default.nix
@@ -59,12 +59,16 @@ let
 
       # the top-level build
       buildTopLevel =
-        build
-          {
-            pname = config.packageName;
-            inherit (config) userAttrs src;
-            builtDependencies = lib.optional (! config.isSingleStep) buildDeps;
-          };
+        let
+          drv =
+            build
+              {
+                pname = config.packageName;
+                inherit (config) userAttrs src;
+                builtDependencies = lib.optional (! config.isSingleStep) buildDeps;
+              };
+        in
+          drv.overrideAttrs config.overrideMain;
     in
       buildTopLevel;
 in


### PR DESCRIPTION
This adds `overrideMain f` which is equivalent to calling
`drv.overrideAttrs f`.

Closes #105 
CC @cole-h 