### PR TITLE
port wasm test to 20.09 and unstable

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -214,4 +214,4 @@ let
 in
 fastTests
 // pkgs.lib.optionalAttrs (! fast) heavyTests
-// pkgs.lib.optionalAttrs (nixpkgs == "nixpkgs-20.03" && pkgs.stdenv.isLinux) muslTests
+// pkgs.lib.optionalAttrs (nixpkgs == "nixpkgs-20.09" && pkgs.stdenv.isLinux) muslTests


### PR DESCRIPTION
Depends on https://github.com/nmattia/naersk/pull/128

Built muslTests with nixpkgs-20.09, but they also evaluate with nixpkgs and nixpkgs-20.03.