### PR TITLE
Also copy local path-dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
             pname = "${config.packageName}-deps";
             src = libb.dummySrc {
               inherit cargoconfig;
-              inherit (config) cargolock cargotomls patchedSources;
+              inherit (config) cargolock cargotomls copySources copySourcesFrom;
             };
             inherit (config) userAttrs;
             # TODO: custom cargoTestCommands should not be needed here


### PR DESCRIPTION
Hello!

I'm trying to use naersk to build a patched `cargo` from source, and in the process of doing so I hit #133.

Here is a PR that partially fixes the issue, and allows setting `copySources` to the dependencies that might still be missed by this non-recursive algorithm.

What do you think about this? It has as drawbacks that path-dependency crates will be compiled twice (once in the “prebuild the deps” phase and once in the “build the code” phase), and also that only direct path-dependencies are (currently) being handled.

What do you think about this approach to #133? Should I try to improve on it, or just to make `copySources` available?

Anyway, thank you for naersk, I'm using it only since recently but it feels really nice to use :)