### PR TITLE
Expose copySource for dealing with path-based dependencies

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -303,13 +303,20 @@ let
       in
         lib.unique (lib.concatMap expandMember listedMembers);
 
-    patchedSources =
+    # If `copySourcesFrom` is set, then it looks like the benefits brought by
+    # two-step caching break, for unclear reasons as of now. As such, do not set
+    # `copySourcesFrom` if there is no source to actually copy from.
+    copySourcesFrom = if copySources != [] then src else null;
+
+    copySources =
       let
         mkRelative = po:
           if lib.hasPrefix "/" po.path
           then throw "'${toString src}/Cargo.toml' contains the absolute path '${toString po.path}' which is not allowed under a [patch] section by naersk. Please make it relative to '${toString src}'"
-          else src + "/" + po.path;
+          else po.path;
       in
+        arg.copySources or []
+      ++
         lib.optionals (builtins.hasAttr "patch" toplevelCargotoml)
           (
             map mkRelative

--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
             pname = "${config.packageName}-deps";
             src = libb.dummySrc {
               inherit cargoconfig;
-              inherit (config) cargolock cargotomls patchedSources;
+              inherit (config) cargolock cargotomls copySources copySourcesFrom;
             };
             inherit (config) userAttrs;
             # TODO: custom cargoTestCommands should not be needed here

--- a/lib.nix
+++ b/lib.nix
@@ -116,7 +116,8 @@ rec
     { cargoconfig   # string
     , cargotomls   # attrset
     , cargolock   # attrset
-    , patchedSources # list of paths that should be copied to the output
+    , copySources # list of paths that should be copied to the output
+    , copySourcesFrom # path from which to copy ${copySources}
     }:
       let
         config = writeText "config" cargoconfig;
@@ -142,15 +143,18 @@ rec
 
       in
         runCommand "dummy-src"
-          { inherit patchedSources cargotomlss; }
+          { inherit copySources copySourcesFrom cargotomlss; }
           ''
             mkdir -p $out/.cargo
             ${lib.optionalString (! isNull cargoconfig) "cp ${config} $out/.cargo/config"}
             cp ${cargolock'} $out/Cargo.lock
 
-            for p in $patchedSources; do
+            for p in $copySources; do
               echo "Copying patched source $p to $out..."
-              cp -R "$p" "$out/"
+              # Create all the directories but $p itself, so `cp -R` does the
+              # right thing below
+              mkdir -p "$out/$(dirname "$p")"
+              cp -R "$copySourcesFrom/$p" "$out/$p"
             done
 
             for tuple in $cargotomlss; do


### PR DESCRIPTION
This is an alternative to https://github.com/nmattia/naersk/pull/135 ; that doesn't try to implement path dependency parsing, as:
1. it'd need to be done recursively, which requires more work
2. it'd have to make sure that workspaces with path dependencies don't end up breaking most if not all the benefits of two-derivation caching
3. in most cases manually filling in `copySources` should not be too bad a thing to do (eg. to compile `cargo` I just had to set `copySources = ["crates"]`), and anyway to get more of the benefit of two-derivation caching there would be very hard (impossible?)

What do you think about this PR?