### PR TITLE
make fetchgit work when not fetching from master

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -108,6 +108,7 @@ rec
                     url = val.git;
                   } // lib.optionalAttrs (val ? rev) {
                     rev = val.rev;
+                    ref = val.rev;
                   } // lib.optionalAttrs (val ? branch) {
                     ref = val.branch;
                   } // lib.optionalAttrs (val ? tag) {


### PR DESCRIPTION
This is required so that fetching dependencies from a feature branch is
possible.

See also https://github.com/NixOS/nix/pull/3408