### PR TITLE
Support flake-based workspaces

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -162,7 +162,7 @@ rec
               # Create all the directories but $p itself, so `cp -R` does the
               # right thing below
               mkdir -p "$out/$(dirname "$p")"
-              cp -R "$copySourcesFrom/$p" "$out/$p"
+              cp --no-preserve=mode -R "$copySourcesFrom/$p" "$out/$p"
             done
 
             for tuple in $cargotomlss; do


### PR DESCRIPTION
Flake sources are nix derivations, which means they automatically get made read-only. This causes overwriting Cargo.toml and potentially build.rs fail. The cure to this is to either chmod the sources after copy, or in this case copy without preserving the file's original mode.