### PR TITLE
Remove deprecated aliases

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -190,7 +190,7 @@ let
       rsync
     ] ++ nativeBuildInputs;
 
-    buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    buildInputs = lib.optionals stdenv.isDarwin [
       darwin.Security
       darwin.apple_sdk.frameworks.CoreServices
       darwin.cf-private

--- a/rust/binary.nix
+++ b/rust/binary.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, bash, curl, darwin
+{ stdenv, lib, makeWrapper, bash, curl, darwin
 , version
 , src
 , platform
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (stdenv.lib) optionalString;
+  inherit (lib) optionalString;
   inherit (darwin.apple_sdk.frameworks) Security;
 
   bootstrapping = versionType == "bootstrap";
@@ -24,7 +24,7 @@ rec {
     inherit version;
     inherit src;
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = http://www.rust-lang.org/;
       description = "A safe, concurrent, practical language";
       maintainers = with maintainers; [ qknight ];
@@ -32,7 +32,7 @@ rec {
     };
 
     buildInputs = [ bash ]
-      ++ stdenv.lib.optional stdenv.isDarwin Security;
+      ++ lib.optional stdenv.isDarwin Security;
 
     postPatch = ''
       patchShebangs .
@@ -70,7 +70,7 @@ rec {
     inherit version;
     inherit src;
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = http://www.rust-lang.org/;
       description = "A safe, concurrent, practical language";
       maintainers = with maintainers; [ qknight ];
@@ -78,7 +78,7 @@ rec {
     };
 
     buildInputs = [ makeWrapper bash ]
-      ++ stdenv.lib.optional stdenv.isDarwin Security;
+      ++ lib.optional stdenv.isDarwin Security;
 
     postPatch = ''
       patchShebangs .

--- a/rust/cargo.nix
+++ b/rust/cargo.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, file, curl, pkgconfig, python3, openssl, cmake, zlib
+{ stdenv, lib, file, curl, pkg-config, python3, openssl, cmake, zlib
 , makeWrapper, libiconv, cacert, rustPlatform, rustc, libgit2
 , CoreFoundation, Security
 }:
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
+  nativeBuildInputs = [ pkg-config cmake makeWrapper ];
   buildInputs = [ cacert file curl python3 openssl zlib libgit2 ]
     ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
 

--- a/rust/cargo.nix
+++ b/rust/cargo.nix
@@ -1,4 +1,4 @@
-{ stdenv, file, curl, pkgconfig, python3, openssl, cmake, zlib
+{ stdenv, lib, file, curl, pkgconfig, python3, openssl, cmake, zlib
 , makeWrapper, libiconv, cacert, rustPlatform, rustc, libgit2
 , CoreFoundation, Security
 }:
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
   buildInputs = [ cacert file curl python3 openssl zlib libgit2 ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
+    ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
 
   LIBGIT2_SYS_USE_PKG_CONFIG = 1;
 
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage {
   # Disable check phase as there are failures (4 tests fail)
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://crates.io;
     description = "Downloads your Rust project's dependencies and builds your project";
     maintainers = with maintainers; [ retrry ];

--- a/rust/clippy.nix
+++ b/rust/clippy.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = [ rustc rustc.llvm ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ rustc rustc.llvm ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
   RUSTC_BOOTSTRAP = 1;
@@ -21,11 +21,11 @@ rustPlatform.buildRustPackage {
   #   (/private/tmp/nix-build-clippy-1.36.0.drv-0/rustc-1.36.0-src/src/librustc_llvm)
   doCheck = false;
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+  preFixup = lib.optionalString stdenv.isDarwin ''
     install_name_tool -add_rpath "${rustc}/lib" $out/bin/clippy-driver
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://rust-lang.github.io/rust-clippy/";
     description = "A bunch of lints to catch common mistakes and improve your Rust code";
     maintainers = with maintainers; [ basvandijk ];

--- a/rust/libunwind.nix
+++ b/rust/libunwind.nix
@@ -1,7 +1,7 @@
 # [naersk] this is needed for proper musl builds
 # We need libunwind-9.0.0 because earlier versions link c++ symbols we don't
 # have to have to link to
-{ fetchurl, stdenv, cmake, enableShared ? true }:
+{ fetchurl, stdenv, lib, cmake, enableShared ? true }:
 let
   version = "9.0.0";
   fetch = sha256: fetchurl {
@@ -19,5 +19,5 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
+  cmakeFlags = lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
 }

--- a/rust/rls/default.nix
+++ b/rust/rls/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, rustPlatform
-, openssh, openssl, pkgconfig, cmake, zlib, curl, libiconv
+, openssh, openssl, pkg-config, cmake, zlib, curl, libiconv
 , CoreFoundation, Security }:
 
 rustPlatform.buildRustPackage {
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
   # rls-rustc links to rustc_private crates
   CARGO_BUILD_RUSTFLAGS = if stdenv.isDarwin then "-C rpath" else null;
 
-  nativeBuildInputs = [ pkgconfig cmake ];
+  nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ openssh openssl curl zlib libiconv rustPlatform.rust.rustc.llvm ]
     ++ (lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
 

--- a/rust/rls/default.nix
+++ b/rust/rls/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform
+{ stdenv, lib, fetchFromGitHub, rustPlatform
 , openssh, openssl, pkgconfig, cmake, zlib, curl, libiconv
 , CoreFoundation, Security }:
 
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ openssh openssl curl zlib libiconv rustPlatform.rust.rustc.llvm ]
-    ++ (stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
+    ++ (lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
 
   doCheck = true;
 
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage {
     $out/bin/rls --version
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Rust Language Server - provides information about Rust programs to IDEs and other tools";
     homepage = "https://github.com/rust-lang/rls/";
     license = with licenses; [ asl20 /* or */ mit ];

--- a/rust/rustc.nix
+++ b/rust/rustc.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchurl, file, python3
 , llvm_9, darwin, git, cmake, rust, rustPlatform
-, pkgconfig, openssl
+, pkg-config, openssl
 , which, libffi
 , withBundledLLVM ? false
 , enableRustcDev ? true
@@ -215,7 +215,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     file python3 rustPlatform.rust.rustc git cmake
-    which libffi removeReferencesTo pkgconfig
+    which libffi removeReferencesTo pkg-config
   ];
 
   buildInputs = [ openssl ]

--- a/rust/rustc.nix
+++ b/rust/rustc.nix
@@ -39,7 +39,7 @@ let
     ++ lib.optionals stdenv.isLinux [ "x86_64-unknown-linux-musl" ]
     ;
   host = stdenv.buildPlatform.config;
-  inherit (stdenv.lib) optionals optional optionalString;
+  inherit (lib) optionals optional optionalString;
   inherit (darwin.apple_sdk.frameworks) Security;
 
 /* [naersk]: no need for this
@@ -225,7 +225,7 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "man" "doc" ];
   setOutputFlags = false;
 
-  postInstall = stdenv.lib.optionalString enableRustcDev ''
+  postInstall = lib.optionalString enableRustcDev ''
     # install rustc-dev components. Necessary to build rls, clippy...
     python x.py dist rustc-dev
     tar xf build/dist/rustc-dev*tar.gz
@@ -249,7 +249,7 @@ in stdenv.mkDerivation rec {
 
   passthru.llvm = llvmShared;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://www.rust-lang.org/";
     description = "A safe, concurrent, practical language";
     maintainers = with maintainers; [ madjar cstrahan globin havvy ];

--- a/rust/rustfmt.nix
+++ b/rust/rustfmt.nix
@@ -1,4 +1,4 @@
-{ stdenv, rustPlatform, Security }:
+{ stdenv, lib, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rustfmt";
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+  buildInputs = lib.optional stdenv.isDarwin Security;
 
   # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
   RUSTC_BOOTSTRAP = 1;
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     cargo build
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A tool for formatting Rust code according to style guidelines";
     homepage = https://github.com/rust-lang-nursery/rustfmt;
     license = with licenses; [ mit asl20 ];


### PR DESCRIPTION
- `stdenv.lib` → `lib`
- `pkgconfig` → `pkg-config`

This fixes a runtime warning.