### PR TITLE
Avoid accidentally pulling `std` for no-std crates

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -177,7 +177,8 @@ rec
                 # make sure cargo is happy
                 pushd $out/$member > /dev/null
                 mkdir -p src
-                touch src/lib.rs
+                # Avoid accidentally pulling `std` for no-std crates.
+                echo '#![no_std]' >src/lib.rs
                 # pretend there's a `build.rs`, otherwise cargo doesn't build
                 # the `[build-dependencies]`. Custom locations of build scripts
                 # aren't an issue because we strip the `build` field in


### PR DESCRIPTION
Fixes #142

The target  `thumbv7m-none-eabi` has only `libcore` without `libstd`.
We should make `dummy-src` to be `no_std` when cross-compiling to these target (by setting `build.target` in `.cargo/config`).
