### PR TITLE
fix(builtins/to-toml): support int type

### DIFF
--- a/builtins/to-toml.nix
+++ b/builtins/to-toml.nix
@@ -77,7 +77,7 @@ let
     let
       ty = tomlTy v;
     in
-      if ty == "bool" then
+      if ty == "bool" || ty == "int" then
         [ "${quoteKey k} = ${outputValInner v}" ]
       else
         if ty == "string" then


### PR DESCRIPTION
Fixes https://github.com/nmattia/naersk/issues/148.

"As of rust-lang/cargo@7dd9872, Cargo adds a new `version = 3` key to
the lockfile's top level"