### PR TITLE
Add libiconv as a dependency for everything on macOS

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -196,6 +196,7 @@ let
       darwin.Security
       darwin.apple_sdk.frameworks.CoreServices
       darwin.cf-private
+      darwin.libiconv
     ] ++ buildInputs;
 
     inherit builtDependencies;


### PR DESCRIPTION
I'm not really sure exactly what changed in more recent versions of rustc but now we need this.