### PR TITLE
ci: run all tests on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,10 @@ on:
       - 'master'
 
 jobs:
-  install-nix:
+  linux:
+    strategy:
+        matrix:
+            nixpkgs: [ nixpkgs, nixpkgs-20.03, nixpkgs-20.09 ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -13,4 +16,15 @@ jobs:
         with:
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
       - name: "Run tests"
-        run: './script/test'
+        run: './script/test --nixpkgs "$nixpkgs" '
+        env:
+            nixpkgs: ${{ matrix.nixpkgs }}
+  darwin:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: './.github/actions/nix'
+        with:
+          CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
+      - name: "Run tests"
+        run: './script/test


### PR DESCRIPTION
Some tests like the wasm one were never executed because they are
neither --fast, nor tested in the main CI.

This copies the fast.yml into test.yml, minus the --fast flag.