### PR TITLE
Update nixpkgs in cross-windows example

### DIFF
--- a/examples/cross-windows/flake.lock
+++ b/examples/cross-windows/flake.lock
@@ -82,11 +82,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1657292830,
-        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "lastModified": 1763312402,
+        "narHash": "sha256-3YJkOBrFpmcusnh7i8GXXEyh7qZG/8F5z5+717550Hk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "rev": "85a6c4a07faa12aaccd81b36ba9bfc2bec974fa1",
         "type": "github"
       },
       "original": {

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -34,12 +34,12 @@
 
           depsBuildBuild = with pkgs; [
             pkgsCross.mingwW64.stdenv.cc
-            pkgsCross.mingwW64.windows.pthreads
           ];
 
           nativeBuildInputs = with pkgs; [
             # We need Wine to run tests:
             wineWowPackages.stable
+            pkgsCross.mingwW64.windows.pthreads
           ];
 
           doCheck = true;


### PR DESCRIPTION
pkgsCross.mingwW64.windows.pthreads is moved to nativeBuildInputs,
otherwise the build fails with latest nixpkgs.
See also <https://github.com/nix-community/naersk/issues/371>.
