### PR TITLE
Update nixpkgs and move pthreads to buildInputs in cross-windows example

### DIFF
--- a/examples/cross-windows/flake.lock
+++ b/examples/cross-windows/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1657347958,
-        "narHash": "sha256-UViOt1l9Qu1StbAIDe+xMjRbkEnefbISbs256J5IcHE=",
+        "lastModified": 1779876442,
+        "narHash": "sha256-O25HomVNmdROO13PEQ3Ran8Hq5EsyLmVn8Gb8JvJtJE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d223a6c360d0873488b70df0a9d27e0f6487b8fe",
+        "rev": "2eff81fc84390a35e1565395ae945d9394856824",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657292830,
-        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "lastModified": 1779593580,
+        "narHash": "sha256-le3WvQyzAQjBZnb7q2c8C5Fk2c9LgN/Oq+b0KiD4fM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "rev": "d849bb215dcdf71bce3e686839ccdb4219e84b2f",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1657292522,
-        "narHash": "sha256-mAxbvJzcpozcQpcfNAP1eU27NgAqT6pDB/eaQOe/piI=",
+        "lastModified": 1779827300,
+        "narHash": "sha256-J6pHxKoZzWCrAvOVInwBcYYWix/NWwM10Ad+i29Qc5s=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2836dd15f753a490ea5b89e02c6cfcecd2f32984",
+        "rev": "c3af07ad84d68adc5e652e86f0c20009caa29014",
         "type": "github"
       },
       "original": {

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -38,14 +38,17 @@
           src = ./.;
           strictDeps = true;
 
-          depsBuildBuild = with pkgs; [
-            pkgsCross.mingwW64.stdenv.cc
-            pkgsCross.mingwW64.windows.pthreads
+          depsBuildBuild = [
+            pkgs.pkgsCross.mingwW64.stdenv.cc
           ];
 
-          nativeBuildInputs = with pkgs; [
+          buildInputs = [
+            pkgs.pkgsCross.mingwW64.windows.pthreads
+          ];
+
+          nativeBuildInputs = [
             # We need Wine to run tests:
-            wineWowPackages.stable
+            pkgs.wineWow64Packages.stable
           ];
 
           doCheck = true;
@@ -54,11 +57,16 @@
           # (https://doc.rust-lang.org/cargo/reference/config.html#buildtarget)
           CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu";
 
+          CARGO_BUILD_RUSTFLAGS = [
+            "-L" "native=${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib"
+          ];
+
           # Tells Cargo that it should use Wine to run tests.
           # (https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner)
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER = pkgs.writeScript "wine-wrapper" ''
+            #!/bin/sh
             export WINEPREFIX="$(mktemp -d)"
-            exec wine64 $@
+            exec wine $@
           '';
         };
       }


### PR DESCRIPTION
Otherwise with new nixpkgs running "nix build" fails with the following error:

       error: Refusing to evaluate package 'mingw_w64-pthreads-13.0.0' in /nix/store/ashn70kmkbfkfqgvzf3badqlb2jpqzlc-source/pkgs/os-specific/windows/mingw-w64/headers.nix:35 because it is not available on the requested hostPlatform:
         hostPlatform.system = "x86_64-linux"
         package.meta.platforms = [
           "aarch64-windows"
           "x86_64-windows"
           "i686-windows"
         ]
         package.meta.badPlatforms = [ ]

Closes #371