### PR TITLE
Fix .cargo-home/config and config.toml warning

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -244,8 +244,6 @@ let
       mkdir -p $CARGO_HOME
 
       cp "$cargoconfig" $CARGO_HOME/config.toml
-      # symlink for backwards compatibility with older cargo
-      ln -s ./config.toml $CARGO_HOME/config
 
       runHook postConfigure
     '';


### PR DESCRIPTION
This PR fixes the warning
```
warning: Both `/build/source/.cargo-home/config` and `/build/source/.cargo-home/config.toml` exist. Using `/build/source/.cargo-home/config`
```
Although it hinted us to create a symlink in #325 , it seems that now it would prefer only one of `.cargo-home/config` and `.cargo-home.toml` .